### PR TITLE
Make 'pas' optional for IDX cmdHisto

### DIFF
--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -330,7 +330,7 @@ def measures_resp2py(resp):
             'help': "type de mesure demandé : IDX pour les index, CDC pour la "
             "courbe de charge.",
         },
-        'pas': {
+        '--pas': {
             'choices': ['10', '30'],
             'help': "pas souhaité dans le cas des courbes de charges ; "
             "10 pour C1-C4 / 30 pour C5",


### PR DESCRIPTION
Had to make 'pas' optional to use the homologation test script.