### PR TITLE
Get injection data from ConsultationMesuresDetaillees/v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,34 +43,36 @@ process.
 Here is a sample code to access to the ``ConsultationMesuresDetaillees`` from
 Python code :
 
-    import datetime
-    import lowatt_enedis
-    import lowatt_enedis.services
+```python
+import datetime
+import lowatt_enedis
+import lowatt_enedis.services
 
-    config = {
-        'login': 'api.sge@lowatt.fr',
-        'certificateFile': 'fullchain.pem',
-        'keyFile': 'privkey.pem',
-        'prm': '30000123456789',
-    }
-    # get client for the 'details' service using appropriate client
-    # certificate and key
-    client = lowatt_enedis.get_client(
-        lowatt_enedis.COMMAND_SERVICE['details'][0],
-        config['certificateFile'], config['keyFile'],
-    )
-    # actually call the web to get values for the past week
-    resp = lowatt_enedis.services.point_detailed_measures(client, {
-        'login': config['login'],
-        'prm': config['prm'],
-        'type': 'COURBE',
-        'courbe_type': 'PA',
-        'corrigee': True,
-        'from': datetime.date.today() - datetime.timedelta(days=7),
-        'to': datetime.date.today(),
-    })
-    # get a list of (UTC timestamp, value(W))
-    data = lowatt_enedis.services.measures_resp2py(resp)
+config = {
+    'login': 'api.sge@lowatt.fr',
+    'certificateFile': 'fullchain.pem',
+    'keyFile': 'privkey.pem',
+    'prm': '30000123456789',
+}
+# get client for the 'details' service using appropriate client
+# certificate and key
+client = lowatt_enedis.get_client(
+    lowatt_enedis.COMMAND_SERVICE['details'][0],
+    config['certificateFile'], config['keyFile'],
+)
+# actually call the web to get values for the past week
+resp = lowatt_enedis.services.point_detailed_measures(client, {
+    'login': config['login'],
+    'prm': config['prm'],
+    'type': 'COURBE',
+    'courbe_type': 'PA',
+    'corrigee': True,
+    'from': datetime.date.today() - datetime.timedelta(days=7),
+    'to': datetime.date.today(),
+})
+# get a list of (UTC timestamp, value(W))
+data = lowatt_enedis.services.measures_resp2py(resp)
+```
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Python code :
         'login': 'api.sge@lowatt.fr',
         'certificateFile': 'fullchain.pem',
         'keyFile': 'privkey.pem',
-        'prm': 30000123456789',
+        'prm': '30000123456789',
     }
     # get client for the 'details' service using appropriate client
     # certificate and key
@@ -64,8 +64,9 @@ Python code :
         'login': config['login'],
         'prm': config['prm'],
         'type': 'COURBE',
+        'courbe_type': 'PA',
         'corrigee': True,
-        'from': datetime.date.today() - datetime.interval(days=7),
+        'from': datetime.date.today() - datetime.timedelta(days=7),
         'to': datetime.date.today(),
     })
     # get a list of (UTC timestamp, value(W))

--- a/lowatt_enedis/__init__.py
+++ b/lowatt_enedis/__init__.py
@@ -92,23 +92,11 @@ def handle_cli_command(command, args):
 
     """
     service, _, handler = COMMAND_SERVICE[command]
-
-    client = get_client(service, args.cert_file, args.key_file)
-
-    if args.homologation:
-        # change service URL to use enedis homologation sandbox. Could be
-        # overrided using 'location' kwargs at client construction time but
-        # would require to know the full port URL - like this we can simply
-        # replace the host part.
-        for method in iter_methods(client):
-            method.location = method.location.replace(
-                b'/sge-b2b.', b'/sge-homologation-b2b.',
-            )
-
+    client = get_client(service, args.cert_file, args.key_file, args.homologation)
     handler(client, args)
 
 
-def get_client(service, cert_file, key_file):
+def get_client(service, cert_file, key_file, homologation=False):
     # Need custom plugin to handle `xs:choice` potentially expected in service
     # arguments. Non-handling this seems to be an outstanding suds bug, see
     # https://stackoverflow.com/questions/5963404/suds-and-choice-tag
@@ -131,6 +119,9 @@ def get_client(service, cert_file, key_file):
         # ConsultationMesuresDetaillees location is also misconfigured
         if method.location == b'http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0':
             method.location = b'https://sge-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0'
+
+        if homologation:
+            method.location = method.location.replace(b'/sge-b2b.', b'/sge-homologation-b2b.')
 
     return client
 

--- a/lowatt_enedis/__init__.py
+++ b/lowatt_enedis/__init__.py
@@ -128,6 +128,10 @@ def get_client(service, cert_file, key_file):
         # verification failure.
         method.location = method.location.replace(b'.erdf.fr', b'.enedis.fr')
 
+        # ConsultationMesuresDetaillees location is also misconfigured
+        if method.location == b'http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0':
+            method.location = b'https://sge-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0'
+
     return client
 
 

--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -274,6 +274,10 @@ def point_measures(client, args):
         "Puissance Réactive Inductive, Puissance Réactive Capacitive, "
         "tension (E), tout).",
     },
+    '--injection' : {
+        'action': 'store_true',
+        'help': "demander les données en injection (soutirage par défaut).",
+    },
 }, MESURES_OPTIONS))
 def cli_point_detailed_measures(client, args):
     resp = point_detailed_measures(client, args)
@@ -299,8 +303,12 @@ def point_detailed_measures(client, args):
             demande.grandeurPhysique = 'EA'
         elif get_option(args, 'type') == 'COURBE':
             demande.grandeurPhysique = get_option(args, 'courbe_type')
-    demande.soutirage = _boolean(True)
-    demande.injection = _boolean(False)
+    if get_option(args, 'injection'):
+        demande.soutirage = _boolean(False)
+        demande.injection = _boolean(True)
+    else:
+        demande.soutirage = _boolean(True)
+        demande.injection = _boolean(False)
     demande.accordClient = _boolean(True)
 
     return client.service.consulterMesuresDetaillees(demande)


### PR DESCRIPTION
Small fixes made to run the sample and get injection data from the ConsultationMesuresDetaillees/v2.0 API.